### PR TITLE
Fix broken init_user() method

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,7 +42,7 @@ def init_user():
     if contact is not None:
         session['fullname'] = contact.first_name + ' ' + contact.last_name
     else:
-        context = _create_unverified_context()
+        context = _create_unverified_context()  # This is an unsecure connection, but the data being received is not sensitive
         banner_info = urlopen('https://wsapi.bethel.edu/username/' + username + '/names', context=context).read().decode('utf-8')
         info_dict = ast.literal_eval(banner_info)['0']
         primary_name = info_dict['firstName']

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import ast
+from ssl import _create_unverified_context
 from urllib.request import urlopen
 
 # Third party imports
@@ -41,7 +42,8 @@ def init_user():
     if contact is not None:
         session['fullname'] = contact.first_name + ' ' + contact.last_name
     else:
-        banner_info = urlopen('http://wsapi.bethel.edu/username/' + username + '/names').read()
+        context = _create_unverified_context()
+        banner_info = urlopen('https://wsapi.bethel.edu/username/' + username + '/names', context=context).read().decode('utf-8')
         info_dict = ast.literal_eval(banner_info)['0']
         primary_name = info_dict['firstName']
         if len(info_dict['prefFirstName']) > 0:


### PR DESCRIPTION
## Description

New users were not being added to classified's db. This looks like an issue from the python upgrade to 3.6. Creating an unverified context seems to fix this, which is what python 2.6 defaulted to.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix
- Venv update needed

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I ran this locally and was able to add a new user to my local app.db

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
